### PR TITLE
replacing stack with BottomNavigationBar for optimizing the widget tree

### DIFF
--- a/lib/screens/get_otp_screen.dart
+++ b/lib/screens/get_otp_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/container.dart';
 import 'package:watch_store/component/text_style.dart';
 import 'package:watch_store/gen/assets.gen.dart';
 import 'package:watch_store/res/dimens.dart';

--- a/lib/screens/mainscreen/main_screen.dart
+++ b/lib/screens/mainscreen/main_screen.dart
@@ -15,7 +15,7 @@ class BtmNavScreenIndex {
 }
 
 class MainScreen extends StatefulWidget {
-  MainScreen({super.key});
+  const MainScreen({super.key});
 
   @override
   State<MainScreen> createState() => _MainScreenState();
@@ -59,66 +59,53 @@ class _MainScreenState extends State<MainScreen> {
     return WillPopScope(
       onWillPop: _onWillPop,
       child: Scaffold(
-        body: Stack(
+        body: IndexedStack(
+          index: selectedIndex,
           children: [
-            Positioned(
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: btmNavHeight,
-                child: IndexedStack(
-                  index: selectedIndex,
-                  children: [
-                    Navigator(
-                      key: _homeKey,
-                      onGenerateRoute: (settings) => MaterialPageRoute(
-                          builder: (context) => const HomeScreen()),
-                    ),
-                    Navigator(
-                      key: _basketKey,
-                      onGenerateRoute: (settings) => MaterialPageRoute(
-                          builder: (context) => const BasketScreen()),
-                    ),
-                    Navigator(
-                      key: _profileKey,
-                      onGenerateRoute: (settings) => MaterialPageRoute(
-                          builder: (context) => const ProfileScreen()),
-                    ),
-                  ],
-                )),
-            Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: Container(
-                  color: AppColors.btmNavColor,
-                  height: btmNavHeight,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      BtmNavItem(
-                          iconSvgPath: Assets.svg.user,
-                          text: "پروفایل",
-                          isActive: selectedIndex == BtmNavScreenIndex.profile,
-                          onTap: () => btmNavOnPressed(
-                              index: BtmNavScreenIndex.profile)),
-                      BtmNavItem(
-                          iconSvgPath: Assets.svg.cart,
-                          text: "سبد خرید",
-                          isActive: selectedIndex == BtmNavScreenIndex.basket,
-                          onTap: () =>
-                              btmNavOnPressed(index: BtmNavScreenIndex.basket)),
-                      BtmNavItem(
-                          iconSvgPath: Assets.svg.home,
-                          text: "خانه",
-                          isActive: selectedIndex == BtmNavScreenIndex.home,
-                          onTap: () =>
-                              btmNavOnPressed(index: BtmNavScreenIndex.home)),
-                    ],
-                  ),
-                ))
+            Navigator(
+              key: _homeKey,
+              onGenerateRoute: (settings) =>
+                  MaterialPageRoute(builder: (context) => const HomeScreen()),
+            ),
+            Navigator(
+              key: _basketKey,
+              onGenerateRoute: (settings) =>
+                  MaterialPageRoute(builder: (context) => const BasketScreen()),
+            ),
+            Navigator(
+              key: _profileKey,
+              onGenerateRoute: (settings) => MaterialPageRoute(
+                  builder: (context) => const ProfileScreen()),
+            ),
           ],
+        ),
+        //btmNavBar
+        bottomNavigationBar: Container(
+          color: AppColors.btmNavColor,
+          height: btmNavHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              BtmNavItem(
+                  iconSvgPath: Assets.svg.user,
+                  text: "پروفایل",
+                  isActive: selectedIndex == BtmNavScreenIndex.profile,
+                  onTap: () =>
+                      btmNavOnPressed(index: BtmNavScreenIndex.profile)),
+              BtmNavItem(
+                  iconSvgPath: Assets.svg.cart,
+                  text: "سبد خرید",
+                  isActive: selectedIndex == BtmNavScreenIndex.basket,
+                  onTap: () =>
+                      btmNavOnPressed(index: BtmNavScreenIndex.basket)),
+              BtmNavItem(
+                  iconSvgPath: Assets.svg.home,
+                  text: "خانه",
+                  isActive: selectedIndex == BtmNavScreenIndex.home,
+                  onTap: () => btmNavOnPressed(index: BtmNavScreenIndex.home)),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:watch_store/component/extention.dart';
 import 'package:watch_store/component/text_style.dart';
 import 'package:watch_store/gen/assets.gen.dart';
-import 'package:watch_store/res/colors.dart';
 import 'package:watch_store/res/dimens.dart';
 import 'package:watch_store/widgets/app_bar.dart';
 import 'package:watch_store/widgets/cart_badge.dart';

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,8 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/container.dart';
-import 'package:flutter/src/widgets/framework.dart';
-import 'package:watch_store/component/text_style.dart';
 import 'package:watch_store/res/dimens.dart';
 import 'package:watch_store/res/strings.dart';
 import 'package:watch_store/widgets/app_text_field.dart';

--- a/lib/screens/send_otp_screen.dart
+++ b/lib/screens/send_otp_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/container.dart';
-import 'package:flutter/src/widgets/framework.dart';
 import 'package:watch_store/gen/assets.gen.dart';
 import 'package:watch_store/res/dimens.dart';
 import 'package:watch_store/component/extention.dart';


### PR DESCRIPTION
The widget stack greatly reduces the performance of the application and additionally increases the widget tree. So, in order to keep scrolling down. It is better to use the bottomNavigationBar flutter parameter.

With all due respect to the dear teacher